### PR TITLE
Allow extra arguments for schema fetching, to support mTLS

### DIFF
--- a/lib/http-calls.js
+++ b/lib/http-calls.js
@@ -23,6 +23,7 @@ const getSchemaById = (registry, schemaId) => new Promise((resolve, reject) => {
     },
     path: `${path}schemas/ids/${schemaId}`,
     auth: username && password ? `${username}:${password}` : null,
+    ...registry.extraRequestOptions,
   };
   const req = protocol.request(requestOptions, (res) => {
     let data = '';

--- a/registry.js
+++ b/registry.js
@@ -9,7 +9,7 @@ const avsc = require('avsc');
 const SchemaCache = require('./lib/schema-cache');
 const {pushSchema, getSchemaById, getLatestVersionForSubject} = require('./lib/http-calls');
 
-function schemas(registryUrl, auth = null) {
+function schemas(registryUrl, auth = null, extraRequestOptions = {}) {
   const parsed = new URL(registryUrl);
   const registry = {
     cache: new SchemaCache(),
@@ -19,6 +19,7 @@ function schemas(registryUrl, auth = null) {
     path: parsed.pathname != null ? parsed.pathname : '/',
     username: parsed.username,
     password: parsed.password,
+    extraRequestOptions: extraRequestOptions,
   };
 
   if(auth != null && (typeof auth === 'object')) {


### PR DESCRIPTION
This lets us supply the `agent` arg to set our own `HttpsAgent`, so we can supply certs.